### PR TITLE
Add a type-safe router

### DIFF
--- a/Basemap Tutorial/swift/MyFirstMapApp.xcodeproj/project.pbxproj
+++ b/Basemap Tutorial/swift/MyFirstMapApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3EA4C34219898CDC006A2AA0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA4C34119898CDC006A2AA0 /* ViewController.swift */; };
 		3EA4C34519898CDC006A2AA0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3EA4C34319898CDC006A2AA0 /* Main.storyboard */; };
 		3EA4C34719898CDC006A2AA0 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3EA4C34619898CDC006A2AA0 /* Images.xcassets */; };
+		627431C71CBDEE2D00684B73 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627431C61CBDEE2D00684B73 /* Router.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		3EA4C34119898CDC006A2AA0 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		3EA4C34419898CDC006A2AA0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		3EA4C34619898CDC006A2AA0 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		627431C61CBDEE2D00684B73 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				3EA4C34319898CDC006A2AA0 /* Main.storyboard */,
 				3EA4C34619898CDC006A2AA0 /* Images.xcassets */,
 				3EA4C33D19898CDC006A2AA0 /* Supporting Files */,
+				627431C61CBDEE2D00684B73 /* Router.swift */,
 			);
 			path = MyFirstMapApp;
 			sourceTree = "<group>";
@@ -98,6 +101,7 @@
 		3EA4C33219898CDC006A2AA0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Esri;
 				TargetAttributes = {
@@ -143,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3EA4C34219898CDC006A2AA0 /* ViewController.swift in Sources */,
+				627431C71CBDEE2D00684B73 /* Router.swift in Sources */,
 				3EA4C34019898CDC006A2AA0 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Basemap Tutorial/swift/MyFirstMapApp.xcodeproj/project.pbxproj
+++ b/Basemap Tutorial/swift/MyFirstMapApp.xcodeproj/project.pbxproj
@@ -57,11 +57,11 @@
 			isa = PBXGroup;
 			children = (
 				3EA4C33F19898CDC006A2AA0 /* AppDelegate.swift */,
+				627431C61CBDEE2D00684B73 /* Router.swift */,
 				3EA4C34119898CDC006A2AA0 /* ViewController.swift */,
 				3EA4C34319898CDC006A2AA0 /* Main.storyboard */,
 				3EA4C34619898CDC006A2AA0 /* Images.xcassets */,
 				3EA4C33D19898CDC006A2AA0 /* Supporting Files */,
-				627431C61CBDEE2D00684B73 /* Router.swift */,
 			);
 			path = MyFirstMapApp;
 			sourceTree = "<group>";

--- a/Basemap Tutorial/swift/MyFirstMapApp/Router.swift
+++ b/Basemap Tutorial/swift/MyFirstMapApp/Router.swift
@@ -1,0 +1,40 @@
+//
+//  Router.swift
+//  MyFirstMapApp
+//
+//  Created by Jeff Kereakoglow on 4/12/16.
+//  Copyright © 2016 Esri. All rights reserved.
+//
+
+import Foundation
+
+/// Usage: `Router.Oceans.URL`
+enum Router {
+  static let baseURLString = "http://services.arcgisonline.com/ArcGIS/rest/services/"
+
+  case LightGray
+  case Ocean
+  case NatGeo
+  case Topo
+  case Imagery
+
+  var URL: NSURL {
+    let path: String = {
+      switch self {
+      case .LightGray:
+        return "Canvas/World_Light_Gray_Base"
+      case .Ocean:
+        return "Ocean_Basemap/MapServer"
+      case .NatGeo:
+        return "NatGeo_World_Map/MapServer"
+      case .Topo:
+        return "World_Topo_Map/MapServer"
+      case .Imagery:
+        return "World_Imagery/MapServer"
+      }
+    }()
+
+    let baseURL = NSURL(string: Router.baseURLString)!
+    return baseURL.URLByAppendingPathComponent(path)
+  }
+}

--- a/Basemap Tutorial/swift/MyFirstMapApp/ViewController.swift
+++ b/Basemap Tutorial/swift/MyFirstMapApp/ViewController.swift
@@ -61,15 +61,15 @@ class ViewController: UIViewController, AGSMapViewLayerDelegate {
         
         switch sender.selectedSegmentIndex {
             case 0:  //gray
-                basemapURL = NSURL(string: "http://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer")
+                basemapURL = Router.LightGray.URL
             case 1:  //oceans
-                basemapURL = NSURL(string: "http://services.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer")
+                basemapURL = Router.Ocean.URL
             case 2:  //nat geo
-                basemapURL = NSURL(string: "http://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer")
+                basemapURL = Router.NatGeo.URL
             case 3:  //topo
-                basemapURL = NSURL(string: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer")
+                basemapURL = Router.Topo.URL
             default:  //sat
-                basemapURL = NSURL(string: "http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer")
+                basemapURL = Router.Imagery.URL
         }
         
         //remove the existing basemap layer


### PR DESCRIPTION
# Description

This is a Swifty way to handle URLs. It's easier to read than long URL strings and, because it's a Swift type, it will work with Xcode's autocompletion tool.
